### PR TITLE
Improve installation instructions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10.6"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     name: Python ${{ matrix.python-version }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ Benchmarking framework for Feature Selection and Feature Ranking algorithms 🚀
 ## Install
 
 1. Installation through [PyPi](https://pypi.org/project/fseval/)
-
-    <small>
-    ⭐️ this is the recommended installation option
-    </small>
+    <sup><sub>
+    ⭐️ RECOMMENDED OPTION
+    </sub></sup>
 
     ```shell
     pip install fseval

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # fseval
 
-[![build status](https://github.com/dunnkers/fseval/actions/workflows/python-app.yml/badge.svg)](https://github.com/dunnkers/fseval/actions/workflows/python-app.yml) [![pypi badge](https://img.shields.io/pypi/v/fseval.svg?maxAge=3600)](https://pypi.org/project/fseval/) [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![Downloads](https://pepy.tech/badge/fseval/month)](https://pepy.tech/project/fseval) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/fseval) [![codecov](https://codecov.io/gh/dunnkers/fseval/branch/master/graph/badge.svg?token=R5ZXH8UPCI)](https://codecov.io/gh/dunnkers/fseval) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/dunnkers/fseval.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/dunnkers/fseval/context:python) ![PyPI - License](https://img.shields.io/pypi/l/fseval) [![DOI](https://zenodo.org/badge/274001213.svg)](https://zenodo.org/badge/latestdoi/274001213) [![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/dunnkers/fseval)
+[![build status](https://github.com/dunnkers/fseval/actions/workflows/python-app.yml/badge.svg)](https://github.com/dunnkers/fseval/actions/workflows/python-app.yml)
+[![pypi badge](https://img.shields.io/pypi/v/fseval.svg?maxAge=3600)](https://pypi.org/project/fseval/)
+[![Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Downloads](https://pepy.tech/badge/fseval/month)](https://pepy.tech/project/fseval) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/fseval)
+[![codecov](https://codecov.io/gh/dunnkers/fseval/branch/master/graph/badge.svg?token=R5ZXH8UPCI)](https://codecov.io/gh/dunnkers/fseval)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/dunnkers/fseval.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/dunnkers/fseval/context:python) ![PyPI - License](https://img.shields.io/pypi/l/fseval)
+[![DOI](https://zenodo.org/badge/274001213.svg)](https://zenodo.org/badge/latestdoi/274001213)
+[![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/dunnkers/fseval)
 
 
 Benchmarking framework for Feature Selection and Feature Ranking algorithms 🚀
@@ -10,9 +17,27 @@ Benchmarking framework for Feature Selection and Feature Ranking algorithms 🚀
 
 ## Install
 
-```shell
-pip install fseval
-```
+1. Installation through [PyPi](https://pypi.org/project/fseval/)
+
+    <small>
+    ⭐️ this is the recommended installation option
+    </small>
+
+    ```shell
+    pip install fseval
+    ```
+
+
+2. Installation from source 
+
+    ```shell
+    git clone https://github.com/dunnkers/fseval.git
+    cd fseval
+    pip install -r requirements.txt
+    pip install .
+    ```
+
+You can now import fseval `import fseval` in your Python code, or use the `fseval` command in your terminal. For an example, run `fseval --help`. For more information, see the documentation link below ⌄. 
 
 ## Documentation
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
         version="3.0.3",
         packages=find_namespace_packages(include=["hydra_plugins.*"])
         + find_packages(include=["fseval", "fseval.*"]),
-        entry_points={"console_scripts": ["fseval = fseval.main:main"]},
+        entry_points={"console_scripts": ["fseval = fseval.main:run_pipeline"]},
         description="Benchmarking framework for Feature Selection and Feature Ranking algorithms 🚀",
         keywords="",
         long_description=LONG_DESC,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import find_namespace_packages, find_packages, setup
 
-with open("README.md", "r") as fh:
+with open("README.md", mode="r", encoding="utf8") as fh:
     LONG_DESC = fh.read()
     setup(
         name="fseval",

--- a/website/docs/quick-start.mdx
+++ b/website/docs/quick-start.mdx
@@ -49,6 +49,23 @@ First, install fseval:
 pip install fseval
 ```
 
+
+:::note Installing from source
+
+If for some reason you would not like to install `fseval` from the PyPi package index using `pip install` like above, you can also install `fseval` right from its Git source. Execute the following:
+
+```
+git clone https://github.com/dunnkers/fseval.git
+cd fseval
+pip install -r requirements.txt
+pip install .
+```
+
+You should now be able to continue in the same way as before ✓.
+
+:::
+
+
 Now you can decide whether you want to define your configuration in _YAML_ or in _Python_. Choose whatever you find most convenient.
 
 


### PR DESCRIPTION
1. 🔨 fixes the console script entry point (In other words: when you install `fseval` using `pip` or from the Git source, a `fseval` command should be available in your terminal. Now it is.).
2. 📄 adds documentation for a second installation method: installing from source. For those who do not want to use the PyPi package index, or just want the cutting-edge version of fseval.
  - 🆕 New notice in the README:
  [![Screenshot 2022-09-17 at 15 44 38](https://user-images.githubusercontent.com/744430/190860112-3fd42c33-3478-4a03-9b18-552447b9b598.png)](https://github.com/dunnkers/fseval/blob/feature/improve-installation-instructions/README.md)
   - 🆕 New notice on the website:
   [![Screenshot 2022-09-17 at 15 42 00](https://user-images.githubusercontent.com/744430/190860085-5e511a0d-7e7f-46c7-896e-f8c0bb2c6acc.png)](https://dunnkers.com/fseval/docs/quick-start/#%EF%B8%8F-quick-start)


🙌🏻